### PR TITLE
fix enum parsing

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-@olm:registry=https://office.pkgs.visualstudio.com/2003b897-e349-46b6-a733-61b32410d686/_packaging/OM/npm/registry/
-
-always-auth=true


### PR DESCRIPTION
**Fix `enum` type parsing regression.**

The node structure of the`enum` type also has a `aliasSymbol` object, so it will go into the alias prasing branch.