### PR TITLE
Add path normalization for Linux

### DIFF
--- a/src/cli/configuration.ts
+++ b/src/cli/configuration.ts
@@ -1,3 +1,5 @@
+import { normalizePath } from '../utils';
+
 export interface ParseConfiguration {
   source: Record<string, string[]>;
   predefinedTypes?: string[];
@@ -14,7 +16,62 @@ export interface RenderConfiguration {
   typeNameMap?: Record<string, string>;
 }
 
+interface LanguageRenderingConfiguration {
+  swift?: RenderConfiguration;
+  kotlin?: RenderConfiguration;
+}
+
 export interface Configuration {
   parsing: ParseConfiguration;
-  rendering: { swift?: RenderConfiguration; kotlin?: RenderConfiguration };
+  rendering: LanguageRenderingConfiguration;
+}
+
+function normalizeRenderConfiguration(basePath: string, config?: RenderConfiguration): RenderConfiguration | undefined {
+  if (!config) {
+    return config;
+  }
+  let { namedTypesTemplatePath, namedTypesOutputPath } = config;
+  const { templates, outputDirectory, typeNameMap } = config;
+
+  namedTypesOutputPath = normalizePath(namedTypesOutputPath, basePath);
+  namedTypesTemplatePath = normalizePath(namedTypesTemplatePath, basePath);
+
+  Object.keys(templates).forEach(key => {
+    templates[key] = normalizePath(templates[key], basePath);
+  });
+
+  Object.keys(outputDirectory).forEach(key => {
+    outputDirectory[key] = normalizePath(outputDirectory[key], basePath);
+  });
+
+  return {
+    templates,
+    outputDirectory,
+    namedTypesTemplatePath,
+    namedTypesOutputPath,
+    typeNameMap,
+  };
+}
+
+export function normalizeConfiguration(config: Configuration, basePath: string): Configuration {
+  const { parsing, rendering } = config;
+  const { source, predefinedTypes, defaultCustomTags, dropInterfaceIPrefix, skipInvalidMethods } = parsing;
+  let { swift: swiftConfig, kotlin: kotlinConfig } = rendering;
+
+  swiftConfig = normalizeRenderConfiguration(basePath, swiftConfig);
+  kotlinConfig = normalizeRenderConfiguration(basePath, kotlinConfig);
+
+  return {
+    parsing: {
+      source,
+      predefinedTypes,
+      defaultCustomTags,
+      dropInterfaceIPrefix,
+      skipInvalidMethods,
+    },
+    rendering: {
+      swift: swiftConfig,
+      kotlin: kotlinConfig,
+    },
+  };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import yargs from 'yargs';
 import { CodeGenerator, RenderingLanguage } from '../generator/CodeGenerator';
-import { Configuration } from './configuration';
+import { Configuration, normalizeConfiguration } from './configuration';
 
 const program = yargs(process.argv.slice(2));
 
@@ -9,10 +9,10 @@ const args = program.config().help().argv;
 
 function run(): void {
   const configPath = args.config as string;
-  const directory = path.dirname(configPath);
-  process.chdir(directory);
+  const projectDirectory = path.resolve(path.dirname(configPath));
+  process.chdir(projectDirectory);
 
-  const config = args as unknown as Configuration;
+  const config = normalizeConfiguration(args as unknown as Configuration, projectDirectory);
 
   const generator = new CodeGenerator();
   Object.entries(config.parsing.source).forEach(([tag, interfacePaths]) => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 export function capitalize(text: string): string {
   if (text.length === 0) {
     return text;
@@ -12,4 +14,12 @@ export function uncapitalize(text: string): string {
   }
 
   return text[0].toLowerCase() + text.slice(1);
+}
+
+export function normalizePath(currentPath: string, basePath: string): string {
+  if (path.isAbsolute(currentPath)) {
+    return currentPath;
+  }
+  const result = path.join(basePath, currentPath);
+  return result;
 }


### PR DESCRIPTION
As mentioned in #51, the path resolving is not stable on Linux.

This PR is to use absolute path instead of relative path.