### PR TITLE
Bump version: 0.4.2-rc1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-gyb",
-  "version": "0.4.1",
+  "version": "0.4.2-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-gyb",
-  "version": "0.4.1",
+  "version": "0.4.2-rc1",
   "description": "Generate Native API based on TS interface",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This version should be compatible with https://github.com/npm/node-semver