### PR TITLE
Migrate to use TypeChecker if possible

### DIFF
--- a/src/parser/ValueParser.ts
+++ b/src/parser/ValueParser.ts
@@ -19,7 +19,6 @@ import {
   TupleType,
   isTupleType,
   EnumField,
-  isDictionaryType,
   isBasicType,
 } from '../types';
 import { isUndefinedOrNull, parseTypeJSDocTags } from './utils';

--- a/src/parser/ValueParser.ts
+++ b/src/parser/ValueParser.ts
@@ -74,7 +74,7 @@ export class ValueParser {
     );
   }
 
-  fieldFromTypeElement(node: ts.TypeElement): Field | null {
+  fieldFromTypeElement(node: ts.Node): Field | null {
     if (!ts.isPropertySignature(node)) {
       return null;
     }
@@ -91,6 +91,10 @@ export class ValueParser {
     const staticValue = this.parseLiteralNode(node.type);
     if (staticValue !== null) {
       return { name, type: staticValue.type, staticValue: staticValue.value, documentation };
+    }
+
+    if (node.type.kind === ts.SyntaxKind.NeverKeyword) {
+      return null;
     }
 
     const valueType = this.valueTypeFromNode(node);
@@ -112,8 +116,10 @@ export class ValueParser {
       return dictionaryType;
     }
 
-    const fields = typeNode.members
-      .map((member) => this.fieldFromTypeElement(member))
+    const fields = this.checker.getPropertiesOfType(this.checker.getTypeAtLocation(typeNode))
+      .map((symbol) => symbol.valueDeclaration)
+      .filter((declaration): declaration is ts.Declaration => declaration !== undefined)
+      .map((declaration) => this.fieldFromTypeElement(declaration))
       .filter((field): field is Field => field !== null);
 
     return {
@@ -409,14 +415,11 @@ export class ValueParser {
 
     const name = node.name.getText();
 
-    const members = node.members
-      .map((item) => this.fieldFromTypeElement(item))
+    const members = this.checker.getPropertiesOfType(this.checker.getTypeAtLocation(node))
+      .map((symbol) => symbol.valueDeclaration)
+      .filter((declaration): declaration is ts.Declaration => declaration !== undefined)
+      .map((declaration) => this.fieldFromTypeElement(declaration))
       .filter((field): field is Field => field !== null);
-
-    const membersInExtendingInterface = this.getExtendingMembersFromInterfaceDeclaration(node);
-    if (membersInExtendingInterface.length) {
-      members.push(...membersInExtendingInterface);
-    }
 
     const symbol = this.checker.getSymbolAtLocation(node.name);
     if (symbol === undefined) {
@@ -600,37 +603,5 @@ export class ValueParser {
     }
 
     return null;
-  }
-
-  private getExtendingMembersFromInterfaceDeclaration(node: ts.InterfaceDeclaration): Field[] {
-    if (!node.heritageClauses?.length) {
-      return [];
-    }
-    const extendHeritageClause = node.heritageClauses.find((item) => item.token === ts.SyntaxKind.ExtendsKeyword);
-    if (!extendHeritageClause) {
-      return [];
-    }
-
-    return extendHeritageClause.types.flatMap((extendingInterface): Field[] => {
-      const type = this.checker.getTypeAtLocation(extendingInterface);
-      const declarations = type.symbol.getDeclarations();
-      if (declarations === undefined || declarations.length !== 1) {
-        throw Error(`Invalid decration of extended interface type ${type.symbol.name}`);
-      }
-      const declaration = declarations[0];
-      const interfaceType = this.parseInterfaceType(declaration);
-
-      if (interfaceType === null) {
-        return [];
-      }
-      if (isDictionaryType(interfaceType)) {
-        throw new ValueParserError(
-          `cannot extend dictionary type ${type.symbol.name}`,
-          'Only extending an interface is supported'
-        );
-      }
-
-      return interfaceType.members;
-    });
   }
 }

--- a/test/value-parser-test.ts
+++ b/test/value-parser-test.ts
@@ -80,8 +80,13 @@ describe('ValueParser', () => {
       [key: string]: string;
     }
 
-    interface ExtendedDictInterface extends DictionaryInterface {
-      booleanMember: boolean;
+    interface InterfaceWithNeverMember {
+      stringMember: string;
+      neverMember: never;
+    }
+
+    interface ExtendedInterfaceWithNeverMember extends InterfaceWithMembers {
+      numberMember: never;
     }
 
     interface RecursiveInterface {
@@ -117,11 +122,27 @@ describe('ValueParser', () => {
     };
     testValueType('extended interface', 'ExtendedInterface', extendedInterfaceType, new Set(), interfacesCode);
 
-    it('Invalid extending of a dictionary type', () => {
-      withTempValueParser('ExtendedDictInterface', parseFunc => {
-        expect(parseFunc).to.throw('cannot extend dictionary type DictionaryInterface');
-      }, new Set(), interfacesCode);
-    });
+    const interfaceWithNeverMemberType: InterfaceType = {
+      kind: ValueTypeKind.interfaceType,
+      name: 'InterfaceWithNeverMember',
+      members: [
+        { name: 'stringMember', type: stringType, documentation: '' },
+      ],
+      documentation: '',
+      customTags: {},
+    };
+    testValueType('interface with never member', 'InterfaceWithNeverMember', interfaceWithNeverMemberType, new Set(), interfacesCode);
+
+    const extendedInterfaceWithNeverMemberType: InterfaceType = {
+      kind: ValueTypeKind.interfaceType,
+      name: 'ExtendedInterfaceWithNeverMember',
+      members: [
+        { name: 'stringMember', type: stringType, documentation: '' },
+      ],
+      documentation: '',
+      customTags: {},
+    };
+    testValueType('extended interface with never member', 'ExtendedInterfaceWithNeverMember', extendedInterfaceWithNeverMemberType, new Set(), interfacesCode);
 
     // TODO: Recursive interface is not handled yet
     // const recursiveInterfaceType: InterfaceType = {


### PR DESCRIPTION
Use `TypeChecker` to fetch the properties of interfaces instead of parsing extended interfaces manually.