### PR TITLE
Update the name format of Enum key for Kotlin

### DIFF
--- a/demo/basic/generated/kotlin/IHtmlApi.kt
+++ b/demo/basic/generated/kotlin/IHtmlApi.kt
@@ -113,8 +113,8 @@ enum class StringEnum {
 }
 
 enum class DefaultEnum(val value: Int) {
-    C(0),
-    D(1);
+    DEFAULT_VALUE_C(0),
+    DEFAULT_VALUE_D(1);
 
     companion object {
         fun find(value: Int) = values().find { it.value == value }

--- a/demo/basic/generated/swift/IHtmlApi.swift
+++ b/demo/basic/generated/swift/IHtmlApi.swift
@@ -110,8 +110,8 @@ public enum StringEnum: String, Codable {
 }
 
 public enum DefaultEnum: Int, Codable {
-  case c = 0
-  case d = 1
+  case defaultValueC = 0
+  case defaultValueD = 1
 }
 
 public struct BaseSize: Codable {

--- a/demo/basic/interfaces.ts
+++ b/demo/basic/interfaces.ts
@@ -26,8 +26,8 @@ enum NumEnum {
 }
 
 enum DefaultEnum {
-  c,
-  d,
+  defaultValueC,
+  defaultValueD,
 }
 
 /**

--- a/src/renderer/value-transformer/KotlinValueTransformer.ts
+++ b/src/renderer/value-transformer/KotlinValueTransformer.ts
@@ -120,6 +120,11 @@ export class KotlinValueTransformer implements ValueTransformer {
   }
 
   convertEnumKey(text: string): string {
-    return text.toUpperCase();
+    return text
+      .replace(/\.?([A-Z]+)/g, (_, p1) => {
+        return '_' + p1;
+      })
+      .replace(/^_/, '')
+      .toUpperCase();
   }
 }


### PR DESCRIPTION
Change the name format of Enum classes' key for Kotlin
name from ts: `leftOfRight`
Kotlin Before: `LEFTTORIGHT`
Kotlin After: `LEFT_TO_RIGHT`