### PR TITLE
Enable renaming non-predefined types

### DIFF
--- a/demo/basic/config.json
+++ b/demo/basic/config.json
@@ -33,7 +33,8 @@
       "namedTypesTemplatePath": "../../example-templates/kotlin-named-types.mustache",
       "namedTypesOutputPath": "generated/kotlin/BridgeTypes.kt",
       "typeNameMap": {
-        "CodeGen_Int": "Int"
+        "CodeGen_Int": "Int",
+        "BaseSize": "JSBaseSize"
       }
     }
   }

--- a/demo/basic/generated/kotlin/IHtmlApi.kt
+++ b/demo/basic/generated/kotlin/IHtmlApi.kt
@@ -29,7 +29,7 @@ interface IHtmlApiBridge {
     fun getHTML(title: String, callback: Callback<String>)
     fun requestRenderingResult()
     fun getSize(callback: Callback<OverriddenFullSize>)
-    fun getAliasSize(callback: Callback<BaseSize>)
+    fun getAliasSize(callback: Callback<JSBaseSize>)
     fun testDictionaryWithAnyKey(dict: Map<String, String>)
 }
 
@@ -65,8 +65,8 @@ open class IHtmlApiBridge(editor: WebEditor, gson: Gson) : JsBridge(editor, gson
         executeJsForResponse(OverriddenFullSize::class.java, "getSize", callback)
     }
 
-    override fun getAliasSize(callback: Callback<BaseSize>) {
-        executeJsForResponse(BaseSize::class.java, "getAliasSize", callback)
+    override fun getAliasSize(callback: Callback<JSBaseSize>) {
+        executeJsForResponse(JSBaseSize::class.java, "getAliasSize", callback)
     }
 
     override fun testDictionaryWithAnyKey(dict: Map<String, String>) {
@@ -131,7 +131,7 @@ class DefaultEnumTypeAdapter : JsonSerializer<DefaultEnum>, JsonDeserializer<Def
     }
 }
 
-data class BaseSize(
+data class JSBaseSize(
     @JvmField val width: Float,
     @JvmField val height: Float,
 )

--- a/src/generator/CodeGenerator.ts
+++ b/src/generator/CodeGenerator.ts
@@ -157,7 +157,7 @@ export class CodeGenerator {
   private getNamedTypeView(namedType: NamedType, valueTransformer: ValueTransformer): NamedTypeView {
     let namedTypeView: NamedTypeView;
     if (isInterfaceType(namedType)) {
-      namedTypeView = new InterfaceTypeView(namedType.name, namedType, valueTransformer);
+      namedTypeView = new InterfaceTypeView(namedType, valueTransformer);
       namedTypeView.custom = true;
     } else {
       namedTypeView = new EnumTypeView(namedType, valueTransformer);

--- a/src/renderer/value-transformer/KotlinValueTransformer.ts
+++ b/src/renderer/value-transformer/KotlinValueTransformer.ts
@@ -15,6 +15,7 @@ import { ValueTransformer } from './ValueTransformer';
 
 export class KotlinValueTransformer implements ValueTransformer {
   constructor(private readonly typeNameMap: Record<string, string>) {}
+
   convertValueType(valueType: ValueType): string {
     if (isBasicType(valueType)) {
       switch (valueType.value) {

--- a/src/renderer/value-transformer/KotlinValueTransformer.ts
+++ b/src/renderer/value-transformer/KotlinValueTransformer.ts
@@ -14,8 +14,7 @@ import {
 import { ValueTransformer } from './ValueTransformer';
 
 export class KotlinValueTransformer implements ValueTransformer {
-  constructor(private readonly predefinedTypes: Record<string, string>) {}
-
+  constructor(private readonly typeNameMap: Record<string, string>) {}
   convertValueType(valueType: ValueType): string {
     if (isBasicType(valueType)) {
       switch (valueType.value) {
@@ -31,11 +30,11 @@ export class KotlinValueTransformer implements ValueTransformer {
     }
 
     if (isInterfaceType(valueType)) {
-      return valueType.name;
+      return this.convertTypeNameFromCustomMap(valueType.name);
     }
 
     if (isEnumType(valueType)) {
-      return valueType.name;
+      return this.convertTypeNameFromCustomMap(valueType.name);
     }
 
     if (isArraryType(valueType)) {
@@ -63,7 +62,7 @@ export class KotlinValueTransformer implements ValueTransformer {
     }
 
     if (isPredefinedType(valueType)) {
-      return this.predefinedTypes[valueType.name] ?? valueType.name;
+      return this.typeNameMap[valueType.name] ?? valueType.name;
     }
 
     throw Error('Type not handled');
@@ -124,5 +123,9 @@ export class KotlinValueTransformer implements ValueTransformer {
       .replace(/\.?([A-Z]+)/g, (_, p1: string) => `_${p1}`)
       .replace(/^_/, '')
       .toUpperCase();
+  }
+
+  convertTypeNameFromCustomMap(name: string): string {
+    return this.typeNameMap[name] ?? name;
   }
 }

--- a/src/renderer/value-transformer/SwiftValueTransformer.ts
+++ b/src/renderer/value-transformer/SwiftValueTransformer.ts
@@ -14,7 +14,7 @@ import {
 import { ValueTransformer } from './ValueTransformer';
 
 export class SwiftValueTransformer implements ValueTransformer {
-  constructor(private readonly predefinedTypes: Record<string, string>) {}
+  constructor(private readonly typeNameMap: Record<string, string>) {}
 
   convertValueType(valueType: ValueType): string {
     if (isBasicType(valueType)) {
@@ -31,11 +31,11 @@ export class SwiftValueTransformer implements ValueTransformer {
     }
 
     if (isInterfaceType(valueType)) {
-      return valueType.name;
+      return this.convertTypeNameFromCustomMap(valueType.name);
     }
 
     if (isEnumType(valueType)) {
-      return valueType.name;
+      return this.convertTypeNameFromCustomMap(valueType.name);
     }
 
     if (isArraryType(valueType)) {
@@ -63,7 +63,7 @@ export class SwiftValueTransformer implements ValueTransformer {
     }
 
     if (isPredefinedType(valueType)) {
-      return this.predefinedTypes[valueType.name] ?? valueType.name;
+      return this.typeNameMap[valueType.name] ?? valueType.name;
     }
 
     throw Error('Type not handled');
@@ -140,4 +140,9 @@ export class SwiftValueTransformer implements ValueTransformer {
 
     return text.slice(0, index).toLowerCase() + text.slice(index);
   }
+
+  convertTypeNameFromCustomMap(name: string): string {
+    return this.typeNameMap[name] ?? name;
+  }
+
 }

--- a/src/renderer/value-transformer/ValueTransformer.ts
+++ b/src/renderer/value-transformer/ValueTransformer.ts
@@ -5,4 +5,5 @@ export interface ValueTransformer {
   convertNonOptionalValueType(valueType: ValueType): string;
   convertValue(value: Value, type: ValueType): string;
   convertEnumKey(text: string): string;
+  convertTypeNameFromCustomMap(name: string): string;
 }

--- a/src/renderer/views/EnumTypeView.ts
+++ b/src/renderer/views/EnumTypeView.ts
@@ -6,7 +6,7 @@ export class EnumTypeView {
   constructor(private enumType: EnumType, private valueTransformer: ValueTransformer) {}
 
   get typeName(): string {
-    return this.enumType.name;
+    return this.valueTransformer.convertTypeNameFromCustomMap(this.enumType.name);
   }
 
   get valueType(): string {
@@ -41,5 +41,9 @@ export class EnumTypeView {
 
   get documentationLines(): string[] {
     return getDocumentationLines(this.enumType.documentation);
+  }
+
+  get customTags(): Record<string, unknown> {
+    return this.enumType.customTags;
   }
 }

--- a/src/renderer/views/InterfaceTypeView.ts
+++ b/src/renderer/views/InterfaceTypeView.ts
@@ -4,10 +4,13 @@ import { ValueTransformer } from '../value-transformer';
 
 export class InterfaceTypeView {
   constructor(
-    readonly typeName: string,
     private readonly interfaceType: InterfaceType,
     private readonly valueTransformer: ValueTransformer
   ) {}
+
+  get typeName(): string {
+    return this.valueTransformer.convertValueType(this.interfaceType);
+  }
 
   get members(): { name: string; type: string; documentationLines: string[]; last: boolean }[] {
     const members = this.interfaceType.members.filter((member) => member.staticValue === undefined);
@@ -39,5 +42,9 @@ export class InterfaceTypeView {
 
   get documentationLines(): string[] {
     return getDocumentationLines(this.interfaceType.documentation);
+  }
+
+  get customTags(): Record<string, unknown> {
+    return this.interfaceType.customTags;
   }
 }


### PR DESCRIPTION
1. Enable the ability to override the type name (even non predefined type) by using `typeNameMap` configuration.
2. Expose the `customTags` from interface types and enum types.