### PR TITLE
Bump async from 2.6.3 to 2.6.4 in /demo/mini-editor/web 

### DIFF
--- a/demo/mini-editor/web/package-lock.json
+++ b/demo/mini-editor/web/package-lock.json
@@ -486,9 +486,9 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.14"
@@ -4678,9 +4678,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"


### PR DESCRIPTION
This PR is checkout from the dependabot's auto-fix PR, because the original PR is blocked by cla PR validation
Original PR: https://github.com/microsoft/ts-gyb/pull/94

Bumps [async](https://github.com/caolan/async) from 2.6.3 to 2.6.4.

Changelog
Sourced from [async's changelog](https://github.com/caolan/async/blob/v2.6.4/CHANGELOG.md).

v2.6.4
Fix potential prototype pollution exploit ([#1828](https://github-redirect.dependabot.com/caolan/async/issues/1828))
Commits
[c6bdaca](https://github.com/caolan/async/commit/c6bdaca4f9175c14fc655d3783c6af6a883e6514) Version 2.6.4
[8870da9](https://github.com/caolan/async/commit/8870da9d5022bab310413041b4079e10db3980b7) Update built files
[4df6754](https://github.com/caolan/async/commit/4df6754ef4e96a742956df8782fee27242a2ea12) update changelog
[8f7f903](https://github.com/caolan/async/commit/8f7f90342a6571ba1c197d747ebed30c368096d2) Fix prototype pollution vulnerability ([#1828](https://github-redirect.dependabot.com/caolan/async/issues/1828))
See full diff in [compare view](https://github.com/caolan/async/compare/v2.6.3...v2.6.4)
Maintainer changes