### PR TITLE
Improve configuration format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,21 @@ Create a json configuration file in your project:
 ```json
 {
   "parsing": {
-    "source": {
-      "default": ["path/to/interfaces.ts"]
+    "targets": {
+      "default": {
+        "source": ["path/to/interfaces.ts"]
+      }
     }
   },
   "rendering": {
     "swift": {
-      "templates": {
-        "default": "path/to/module-interface.mustache"
-      },
-      "outputPath": {
-        "default": "path/to/output/directory"
-      },
+      "renders": [
+        {
+          "target": "default",
+          "templates": "path/to/module-interface.mustache",
+          "outputPath": "path/to/output/directory"
+        }
+      ],
       "namedTypesTemplatePath": "path/to/named-types.mustache",
       "namedTypesOutputPath": "path/to/output/directory/SharedTypes.swift"
     }

--- a/demo/basic/config.json
+++ b/demo/basic/config.json
@@ -1,7 +1,9 @@
 {
   "parsing": {
-    "source": {
-      "api": ["interfaces.ts"]
+    "targets": {
+      "api": {
+        "source": ["interfaces.ts"]
+      }
     },
     "predefinedTypes": [
       "CodeGen_Int"
@@ -11,12 +13,13 @@
   },
   "rendering": {
     "swift": {
-      "templates": {
-        "api": "../../example-templates/swift-bridge.mustache"
-      },
-      "outputPath": {
-        "api": "generated/swift"
-      },
+      "renders": [
+        {
+          "target": "api",
+          "template": "../../example-templates/swift-bridge.mustache",
+          "outputPath": "generated/swift"
+        }
+      ],
       "namedTypesTemplatePath": "../../example-templates/swift-named-types.mustache",
       "namedTypesOutputPath": "generated/swift/SharedTypes.swift",
       "typeNameMap": {
@@ -24,12 +27,13 @@
       }
     },
     "kotlin": {
-      "templates": {
-        "api": "../../example-templates/kotlin-bridge.mustache"
-      },
-      "outputPath": {
-        "api": "generated/kotlin"
-      },
+      "renders": [
+        {
+          "target": "api",
+          "template": "../../example-templates/kotlin-bridge.mustache",
+          "outputPath": "generated/kotlin"
+        }
+      ],
       "namedTypesTemplatePath": "../../example-templates/kotlin-named-types.mustache",
       "namedTypesOutputPath": "generated/kotlin/BridgeTypes.kt",
       "typeNameMap": {

--- a/demo/mini-editor/web/config.json
+++ b/demo/mini-editor/web/config.json
@@ -1,9 +1,9 @@
 {
   "parsing": {
-    "source": {
-      "api": [
-        "src/editor/IEditor.ts"
-      ]
+    "targets": {
+      "api": {
+        "source": ["src/editor/IEditor.ts"]
+      }
     },
     "predefinedTypes": [
       "CodeGen_Int"
@@ -13,12 +13,13 @@
   },
   "rendering": {
     "swift": {
-      "templates": {
-        "api": "code-templates/swift.mustache"
-      },
-      "outputPath": {
-        "api": "../apple/MiniEditor/Generated"
-      },
+      "renders": [
+        {
+          "target": "api",
+          "template": "code-templates/swift.mustache",
+          "outputPath": "../apple/MiniEditor/Generated"
+        }
+      ],
       "namedTypesTemplatePath": "../../../example-templates/swift-named-types.mustache",
       "namedTypesOutputPath": "../apple/MiniEditor/Generated/WebEditorTypes.swift",
       "typeNameMap": {
@@ -26,12 +27,13 @@
       }
     },
     "kotlin": {
-      "templates": {
-        "api": "code-templates/kotlin.mustache"
-      },
-      "outputPath": {
-        "api": "../android/app/src/main/java/com/microsoft/tscodegen/demo/minieditor/generated"
-      },
+      "renders": [
+        {
+          "target": "api",
+          "template": "code-templates/kotlin.mustache",
+          "outputPath": "../android/app/src/main/java/com/microsoft/tscodegen/demo/minieditor/generated"
+        }
+      ],
       "namedTypesTemplatePath": "../../../example-templates/kotlin-named-type.mustache",
       "namedTypesOutputPath": "../android/app/src/main/java/com/microsoft/tscodegen/demo/minieditor/generated/BridgeTypes.kt",
       "typeNameMap": {

--- a/src/cli/configuration.ts
+++ b/src/cli/configuration.ts
@@ -2,13 +2,16 @@ import { normalizePath } from '../utils';
 
 export interface TargetParseConfiguration {
   /**
-   * Scoped source file paths. The key is the scope name and the value is an array of the source file paths. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are allowed.
+   * Source file paths. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are allowed.
    * If it is a relative path, it will be resolved based on the configuration file path.
    *
-   * For example, `{ "api": ["src/api/IEditor.ts", "src/bridge/*.ts"] }`
+   * For example, `["src/api/IEditor.ts", "src/bridge/*.ts"]`
    */
   source: string[];
-
+  /**
+   * Interface names for detecting exported modules. If defined, only interfaces that extends the specified interfaces will be parsed.
+   * If not defined, interfaces with JSDoc tag `@shouldExport true` would be parsed
+   */
   extendedInterfaces?: string[];
 }
 
@@ -16,6 +19,10 @@ export interface TargetParseConfiguration {
  * Parser configuration
  */
 export interface ParseConfiguration {
+  /**
+   * Target parse configuration.
+   */
+  targets: Record<string, TargetParseConfiguration>;
   /**
    * Names for pre-defined types.
    * For example, `CodeGen_Int` for mapping for `number` to integers.
@@ -34,22 +41,21 @@ export interface ParseConfiguration {
    * Skip the code generation for invalid methods. If `false`, the code generation will fail when encounter an unsupported type.
    */
   skipInvalidMethods?: boolean;
-  targets: Record<string, TargetParseConfiguration>;
 }
 
 export interface TargetRenderConfiguration {
+  /**
+   * Name of the target to be rendered. Targets are defined in `parsing.targets`.
+   */
   target: string;
   /**
-   * Scoped template file paths. The key is the scope name and the value is the template file path.
-   * If it is a relative path, it will be resolved based on the configuration file path.
+   * Template file paths. If it is a relative path, it will be resolved based on the configuration file path.
    */
   template: string;
   /**
-   * Scoped output directories or paths. The key is the scope name and the value is the output directory or file path.
+   * Output directories or paths. If it is a relative path, it will be resolved based on the configuration file path.
    *
-   * If it is a relative path, it will be resolved based on the configuration file path.
-   *
-   * For example, `{ "api": "../ios/AppTarget/Generated" }`
+   * For example, `"../ios/AppTarget/Generated"`
    */
   outputPath: string;
 }
@@ -58,6 +64,9 @@ export interface TargetRenderConfiguration {
  * Renderer configuration
  */
 export interface RenderConfiguration {
+  /**
+   * A list of render configurations.
+   */
   renders: TargetRenderConfiguration[];
   
   /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import yargs from 'yargs';
-import { CodeGenerator, RenderingLanguage } from '../generator/CodeGenerator';
-import { Configuration, normalizeConfiguration, RenderConfiguration } from './configuration';
+import { CodeGenerator } from '../generator/CodeGenerator';
+import { Configuration, normalizeConfiguration, RenderConfiguration } from '../configuration';
 
 const program = yargs(process.argv.slice(2));
 
@@ -31,52 +31,7 @@ function generate(args: { config: string }): void {
   const config = parseConfig(args.config);
 
   const generator = new CodeGenerator();
-  Object.entries(config.parsing.targets).forEach(([tag, scope]) => {
-    generator.parse({
-      tag,
-      interfacePaths: scope.source,
-      predefinedTypes: new Set(config.parsing.predefinedTypes ?? []),
-      defaultCustomTags: config.parsing.defaultCustomTags ?? {},
-      dropInterfaceIPrefix: config.parsing.dropInterfaceIPrefix ?? false,
-      skipInvalidMethods: config.parsing.skipInvalidMethods ?? false,
-      extendedInterfaces: scope.extendedInterfaces,
-    });
-  });
-
-  generator.parseNamedTypes();
-  generator.printSharedNamedTypes();
-
-  Object.entries(config.parsing.targets).forEach(([tag]) => {
-    generator.printModules({ tag });
-  });
-
-  const languageRenderingConfigs = [
-    { language: RenderingLanguage.Swift, renderingConfig: config.rendering.swift },
-    { language: RenderingLanguage.Kotlin, renderingConfig: config.rendering.kotlin },
-  ];
-
-  languageRenderingConfigs.forEach(({ language, renderingConfig }) => {
-    if (renderingConfig === undefined) {
-      return;
-    }
-
-    renderingConfig.renders.forEach((render) => {
-      generator.renderModules({
-        tag: render.target,
-        language,
-        outputPath: render.outputPath,
-        moduleTemplatePath: render.template,
-        typeNameMap: renderingConfig.typeNameMap ?? {},
-      });
-    });
-
-    generator.renderNamedTypes({
-      language,
-      namedTypesTemplatePath: renderingConfig.namedTypesTemplatePath,
-      namedTypesOutputPath: renderingConfig.namedTypesOutputPath,
-      typeNameMap: renderingConfig.typeNameMap ?? {},
-    });
-  });
+  generator.generate(config);
 }
 
 function listOutput(args: { config: string; language?: 'swift' | 'kotlin'; expand: boolean }): void {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -16,7 +16,7 @@ export interface TargetParseConfiguration {
    * interface SomeInterface extends ExportedInterface {}
    * ```
    */
-  extendedInterfaces?: string[];
+  exportedInterfaceBases?: string[];
 }
 
 /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,4 @@
-import { normalizePath } from '../utils';
+import { normalizePath } from './utils';
 
 export interface TargetParseConfiguration {
   /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,7 +10,11 @@ export interface TargetParseConfiguration {
   source: string[];
   /**
    * Interface names for detecting exported modules. If defined, only interfaces that extends the specified interfaces will be parsed.
-   * If not defined, interfaces with JSDoc tag `@shouldExport true` would be parsed
+   * If not defined, interfaces with JSDoc tag `@shouldExport true` would be parsed.
+   * For example, set it to `["ExportedInterface"]`, all such interfaces would be exported:
+   * ```ts
+   * interface SomeInterface extends ExportedInterface {}
+   * ```
    */
   extendedInterfaces?: string[];
 }

--- a/src/generator/CodeGenerator.ts
+++ b/src/generator/CodeGenerator.ts
@@ -21,15 +21,15 @@ export class CodeGenerator {
   private namedTypes?: NamedTypesResult;
 
   generate(config: Configuration): void {
-    Object.entries(config.parsing.targets).forEach(([tag, scope]) => {
+    Object.entries(config.parsing.targets).forEach(([tag, target]) => {
       this.parse({
         tag,
-        interfacePaths: scope.source,
+        interfacePaths: target.source,
         predefinedTypes: new Set(config.parsing.predefinedTypes ?? []),
         defaultCustomTags: config.parsing.defaultCustomTags ?? {},
         dropInterfaceIPrefix: config.parsing.dropInterfaceIPrefix ?? false,
         skipInvalidMethods: config.parsing.skipInvalidMethods ?? false,
-        extendedInterfaces: scope.extendedInterfaces,
+        exportedInterfaceBases: target.exportedInterfaceBases,
       });
     });
 
@@ -76,7 +76,7 @@ export class CodeGenerator {
     defaultCustomTags,
     dropInterfaceIPrefix,
     skipInvalidMethods,
-    extendedInterfaces,
+    exportedInterfaceBases,
   }: {
     tag: string;
     interfacePaths: string[];
@@ -84,9 +84,9 @@ export class CodeGenerator {
     defaultCustomTags: Record<string, unknown>;
     dropInterfaceIPrefix: boolean;
     skipInvalidMethods: boolean;
-    extendedInterfaces: string[] | undefined;
+    exportedInterfaceBases: string[] | undefined;
   }): void {
-    const parser = new Parser(interfacePaths, predefinedTypes, skipInvalidMethods, extendedInterfaces !== undefined ? new Set(extendedInterfaces) : undefined);
+    const parser = new Parser(interfacePaths, predefinedTypes, skipInvalidMethods, exportedInterfaceBases !== undefined ? new Set(exportedInterfaceBases) : undefined);
     const modules = parser.parse();
 
     modules.forEach((module) => applyDefaultCustomTags(module, defaultCustomTags));

--- a/src/generator/CodeGenerator.ts
+++ b/src/generator/CodeGenerator.ts
@@ -26,6 +26,7 @@ export class CodeGenerator {
     defaultCustomTags,
     dropInterfaceIPrefix,
     skipInvalidMethods,
+    extendedInterfaces,
   }: {
     tag: string;
     interfacePaths: string[];
@@ -33,8 +34,9 @@ export class CodeGenerator {
     defaultCustomTags: Record<string, unknown>;
     dropInterfaceIPrefix: boolean;
     skipInvalidMethods: boolean;
+    extendedInterfaces: string[] | undefined;
   }): void {
-    const parser = new Parser(interfacePaths, predefinedTypes, skipInvalidMethods);
+    const parser = new Parser(interfacePaths, predefinedTypes, skipInvalidMethods, extendedInterfaces !== undefined ? new Set(extendedInterfaces) : undefined);
     const modules = parser.parse();
 
     modules.forEach((module) => applyDefaultCustomTags(module, defaultCustomTags));

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -12,7 +12,7 @@ export class Parser {
 
   private valueParser: ValueParser;
 
-  constructor(globPatterns: string[], predefinedTypes: Set<string>, skipInvalidMethods = false, private readonly extendedInterfaces: Set<string> | undefined) {
+  constructor(globPatterns: string[], predefinedTypes: Set<string>, skipInvalidMethods = false, private readonly exportedInterfaceBases: Set<string> | undefined) {
     const filePaths = globPatterns.flatMap((pattern) => glob.sync(pattern));
     this.program = ts.createProgram({
       rootNames: filePaths,
@@ -51,12 +51,12 @@ export class Parser {
       throw Error('Invalid module node');
     }
 
-    const extendedInterfaces = node.heritageClauses?.flatMap((heritageClause) => heritageClause.types.map((type) => type.getText())) ?? [];
+    const exportedInterfaceBases = node.heritageClauses?.flatMap((heritageClause) => heritageClause.types.map((type) => type.getText())) ?? [];
 
     const jsDocTagsResult = parseTypeJSDocTags(symbol);
 
-    if (this.extendedInterfaces !== undefined) {
-      if (!(extendedInterfaces.some((extendedInterface) => this.extendedInterfaces?.has(extendedInterface)))) {
+    if (this.exportedInterfaceBases !== undefined) {
+      if (!(exportedInterfaceBases.some((extendedInterface) => this.exportedInterfaceBases?.has(extendedInterface)))) {
         return null;
       }
     } else if (!jsDocTagsResult.shouldExport) {
@@ -70,7 +70,7 @@ export class Parser {
         members: result.members,
         methods: result.methods,
         documentation: result.documentation,
-        extendedInterfaces,
+        exportedInterfaceBases,
         customTags: result.customTags,
       };
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -51,10 +51,12 @@ export class Parser {
       throw Error('Invalid module node');
     }
 
+    const extendedInterfaces = node.heritageClauses?.flatMap((heritageClause) => heritageClause.types.map((type) => type.getText())) ?? [];
+
     const jsDocTagsResult = parseTypeJSDocTags(symbol);
 
     if (this.extendedInterfaces !== undefined) {
-      if (!(node.heritageClauses?.some((heritageClause) => heritageClause.types.some((type) => this.extendedInterfaces?.has(type.getText()))))) {
+      if (!(extendedInterfaces.some((extendedInterface) => this.extendedInterfaces?.has(extendedInterface)))) {
         return null;
       }
     } else if (!jsDocTagsResult.shouldExport) {
@@ -68,6 +70,7 @@ export class Parser {
         members: result.members,
         methods: result.methods,
         documentation: result.documentation,
+        extendedInterfaces,
         customTags: result.customTags,
       };
     }

--- a/src/parser/Parser.ts
+++ b/src/parser/Parser.ts
@@ -12,7 +12,7 @@ export class Parser {
 
   private valueParser: ValueParser;
 
-  constructor(globPatterns: string[], predefinedTypes: Set<string>, skipInvalidMethods: boolean) {
+  constructor(globPatterns: string[], predefinedTypes: Set<string>, skipInvalidMethods = false, private readonly extendedInterfaces: Set<string> | undefined) {
     const filePaths = globPatterns.flatMap((pattern) => glob.sync(pattern));
     this.program = ts.createProgram({
       rootNames: filePaths,
@@ -53,7 +53,11 @@ export class Parser {
 
     const jsDocTagsResult = parseTypeJSDocTags(symbol);
 
-    if (!jsDocTagsResult.shouldExport) {
+    if (this.extendedInterfaces !== undefined) {
+      if (!(node.heritageClauses?.some((heritageClause) => heritageClause.types.some((type) => this.extendedInterfaces?.has(type.getText()))))) {
+        return null;
+      }
+    } else if (!jsDocTagsResult.shouldExport) {
       return null;
     }
 

--- a/src/renderer/views/ModuleView.ts
+++ b/src/renderer/views/ModuleView.ts
@@ -30,6 +30,10 @@ export class ModuleView {
     return this.module.methods.map((method) => new MethodView(method, this.valueTransformer));
   }
 
+  get extendedInterfaces(): Record<string, boolean> {
+    return Object.fromEntries(this.module.extendedInterfaces.map((extendedInterface) => [extendedInterface, true]));
+  }
+
   get customTags(): Record<string, unknown> {
     return this.module.customTags;
   }

--- a/src/renderer/views/ModuleView.ts
+++ b/src/renderer/views/ModuleView.ts
@@ -30,8 +30,8 @@ export class ModuleView {
     return this.module.methods.map((method) => new MethodView(method, this.valueTransformer));
   }
 
-  get extendedInterfaces(): Record<string, boolean> {
-    return Object.fromEntries(this.module.extendedInterfaces.map((extendedInterface) => [extendedInterface, true]));
+  get exportedInterfaceBases(): Record<string, boolean> {
+    return Object.fromEntries(this.module.exportedInterfaceBases.map((extendedInterface) => [extendedInterface, true]));
   }
 
   get customTags(): Record<string, unknown> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface Module {
   members: Field[];
   methods: Method[];
   documentation: string;
-  extendedInterfaces: string[];
+  exportedInterfaceBases: string[];
   customTags: Record<string, unknown>;
 }
 
@@ -58,7 +58,7 @@ export interface BasicType extends BaseValueType {
   value: BasicTypeValue;
 }
 
-export interface InterfaceType extends BaseValueType, Omit<Module, 'extendedInterfaces'> {
+export interface InterfaceType extends BaseValueType, Omit<Module, 'exportedInterfaceBases'> {
   kind: ValueTypeKind.interfaceType;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface Module {
   members: Field[];
   methods: Method[];
   documentation: string;
+  extendedInterfaces: string[];
   customTags: Record<string, unknown>;
 }
 
@@ -57,7 +58,7 @@ export interface BasicType extends BaseValueType {
   value: BasicTypeValue;
 }
 
-export interface InterfaceType extends BaseValueType, Module {
+export interface InterfaceType extends BaseValueType, Omit<Module, 'extendedInterfaces'> {
   kind: ValueTypeKind.interfaceType;
 }
 

--- a/test/parser-test.ts
+++ b/test/parser-test.ts
@@ -25,7 +25,7 @@ describe('Parser', () => {
         name: 'ExportTrueInterface',
         members:[],
         methods: [],
-        extendedInterfaces: [],
+        exportedInterfaceBases: [],
         documentation: '',
         customTags: {}
       }]);
@@ -60,7 +60,7 @@ describe('Parser', () => {
           isAsync: false,
           documentation: '',
         }], 
-        extendedInterfaces: [],
+        exportedInterfaceBases: [],
         documentation: '',
         customTags: {},
       }]);
@@ -101,7 +101,7 @@ describe('Parser', () => {
           isAsync: false,
           documentation: 'This is an example documentation for the method',
         }], 
-        extendedInterfaces: [],
+        exportedInterfaceBases: [],
         documentation: 'This is an example documentation for the module',
         customTags: {},
       }]);

--- a/test/parser-test.ts
+++ b/test/parser-test.ts
@@ -21,7 +21,14 @@ describe('Parser', () => {
       `;
     withTempParser(sourceCode, parser => {
       const modules = parser.parse();
-      expect(modules).to.deep.equal([{name: 'ExportTrueInterface', members:[], methods: [], documentation: '', customTags: {}}]);
+      expect(modules).to.deep.equal([{
+        name: 'ExportTrueInterface',
+        members:[],
+        methods: [],
+        extendedInterfaces: [],
+        documentation: '',
+        customTags: {}
+      }]);
     });
   });
 
@@ -53,6 +60,7 @@ describe('Parser', () => {
           isAsync: false,
           documentation: '',
         }], 
+        extendedInterfaces: [],
         documentation: '',
         customTags: {},
       }]);
@@ -93,6 +101,7 @@ describe('Parser', () => {
           isAsync: false,
           documentation: 'This is an example documentation for the method',
         }], 
+        extendedInterfaces: [],
         documentation: 'This is an example documentation for the module',
         customTags: {},
       }]);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,7 +11,7 @@ export function withTempParser(sourceCode: string, handler: (parser: Parser) => 
   const filePath = path.join(tempPath, `${UUID()}.ts`);
   fs.writeFileSync(filePath, sourceCode);
 
-  const parser = new Parser([filePath], predefinedTypes, false);
+  const parser = new Parser([filePath], predefinedTypes, false, undefined);
   handler(parser);
 
   fs.rmdirSync(tempPath, { recursive: true });


### PR DESCRIPTION
- Change `parsing.source` to `parsing.targets`.
- Add `parsing.exportedInterfaceBases` to allow interface based parsing.
- Merge `rendering.outputPath` and `rendering.template`, and change from object to array to avoid duplication.