### PR TITLE
Expose APIs for customized generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "dist/**/*.js",
     "dist/**/*.d.ts"
   ],
-  "types": "index.d.ts",
   "devDependencies": {
     "@types/chai": "^4.2.18",
     "@types/mocha": "^9.0.0",

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -15,7 +15,7 @@ export function generateWithConfig(config: Configuration): void {
       .map(([target, targetConfig]) => ([target, generator.parseTarget(targetConfig.source, targetConfig.exportedInterfaceBases !== undefined ? new Set(targetConfig.exportedInterfaceBases) : undefined)]))
   );
 
-  let sharedTypes = generator.extractSharedTypes(Object.values(namedTargets));
+  let sharedTypes = generator.extractTargetsSharedTypes(Object.values(namedTargets));
   sharedTypes = sharedTypes.concat(Object.values(namedTargets).flatMap((target) => target.sharedTypes));
   generator.printSharedTypes(sharedTypes);
 

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -1,0 +1,58 @@
+import { CodeGenerator, RenderingLanguage } from '../generator/CodeGenerator';
+import { Configuration } from '../configuration';
+import { ParsedTarget } from '../generator/named-types';
+
+export function generateWithConfig(config: Configuration): void {
+  const generator = new CodeGenerator(
+    new Set(config.parsing.predefinedTypes ?? []),
+    config.parsing.defaultCustomTags ?? {},
+    config.parsing.skipInvalidMethods ?? false,
+    config.parsing.dropInterfaceIPrefix ?? false
+  );
+
+  const namedTargets = Object.fromEntries(
+    Object.entries(config.parsing.targets)
+      .map(([target, targetConfig]) => ([target, generator.parseTarget(targetConfig.source, targetConfig.exportedInterfaceBases !== undefined ? new Set(targetConfig.exportedInterfaceBases) : undefined)]))
+  );
+
+  let sharedTypes = generator.extractSharedTypes(Object.values(namedTargets));
+  sharedTypes = sharedTypes.concat(Object.values(namedTargets).flatMap((target) => target.sharedTypes));
+  generator.printSharedTypes(sharedTypes);
+
+  Object.values(namedTargets).forEach((target) => {
+    generator.printTarget(target.modules);
+  });
+
+  const languageRenderingConfigs = [
+    { language: RenderingLanguage.Swift, renderingConfig: config.rendering.swift },
+    { language: RenderingLanguage.Kotlin, renderingConfig: config.rendering.kotlin },
+  ];
+
+  languageRenderingConfigs.forEach(({ language, renderingConfig }) => {
+    if (renderingConfig === undefined) {
+      return;
+    }
+
+    renderingConfig.renders.forEach((render) => {
+      const target = namedTargets[render.target] as ParsedTarget | undefined;
+      if (target === undefined) {
+        throw new Error(`target ${render.target} is not defined in the configuration file`);
+      }
+      generator.renderModules(target.modules, {
+        language,
+        outputPath: render.outputPath,
+        templatePath: render.template,
+        typeNameMap: renderingConfig.typeNameMap ?? {},
+      });
+    });
+
+    if (sharedTypes.length > 0) {
+      generator.renderNamedTypes(sharedTypes, {
+        language,
+        outputPath: renderingConfig.namedTypesOutputPath,
+        templatePath: renderingConfig.namedTypesTemplatePath,
+        typeNameMap: renderingConfig.typeNameMap ?? {},
+      });
+    }
+  });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import fs from 'fs';
 import yargs from 'yargs';
-import { CodeGenerator } from '../generator/CodeGenerator';
+import { CodeGenerator, RenderingLanguage } from '../generator/CodeGenerator';
 import { Configuration, normalizeConfiguration, RenderConfiguration } from '../configuration';
+import { ParsedTarget } from '../generator/named-types';
 
 const program = yargs(process.argv.slice(2));
 
@@ -30,8 +31,58 @@ function run(): void {
 function generate(args: { config: string }): void {
   const config = parseConfig(args.config);
 
-  const generator = new CodeGenerator();
-  generator.generate(config);
+  const generator = new CodeGenerator(
+    new Set(config.parsing.predefinedTypes ?? []),
+    config.parsing.defaultCustomTags ?? {},
+    config.parsing.skipInvalidMethods ?? false,
+    config.parsing.dropInterfaceIPrefix ?? false
+  );
+
+  const namedTargets = Object.fromEntries(
+    Object.entries(config.parsing.targets)
+      .map(([target, targetConfig]) => ([target, generator.parseTarget(targetConfig.source, targetConfig.exportedInterfaceBases !== undefined ? new Set(targetConfig.exportedInterfaceBases) : undefined)]))
+  );
+
+  let sharedTypes = generator.extractSharedTypes(Object.values(namedTargets));
+  sharedTypes = sharedTypes.concat(Object.values(namedTargets).flatMap((target) => target.sharedTypes));
+  generator.printSharedTypes(sharedTypes);
+
+  Object.values(namedTargets).forEach((target) => {
+    generator.printTarget(target.modules);
+  });
+
+  const languageRenderingConfigs = [
+    { language: RenderingLanguage.Swift, renderingConfig: config.rendering.swift },
+    { language: RenderingLanguage.Kotlin, renderingConfig: config.rendering.kotlin },
+  ];
+
+  languageRenderingConfigs.forEach(({ language, renderingConfig }) => {
+    if (renderingConfig === undefined) {
+      return;
+    }
+
+    renderingConfig.renders.forEach((render) => {
+      const target = namedTargets[render.target] as ParsedTarget | undefined;
+      if (target === undefined) {
+        throw new Error(`target ${render.target} is not defined in the configuration file`);
+      }
+      generator.renderModules(target.modules, {
+        language,
+        outputPath: render.outputPath,
+        templatePath: render.template,
+        typeNameMap: renderingConfig.typeNameMap ?? {},
+      });
+    });
+
+    if (sharedTypes.length > 0) {
+      generator.renderNamedTypes(sharedTypes, {
+        language,
+        outputPath: renderingConfig.namedTypesOutputPath,
+        templatePath: renderingConfig.namedTypesTemplatePath,
+        typeNameMap: renderingConfig.typeNameMap ?? {},
+      });
+    }
+  });
 }
 
 function listOutput(args: { config: string; language?: 'swift' | 'kotlin'; expand: boolean }): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,9 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import yargs from 'yargs';
-import { CodeGenerator, RenderingLanguage } from '../generator/CodeGenerator';
 import { Configuration, normalizeConfiguration, RenderConfiguration } from '../configuration';
-import { ParsedTarget } from '../generator/named-types';
+import { generateWithConfig } from './generate';
 
 const program = yargs(process.argv.slice(2));
 
@@ -31,58 +30,7 @@ function run(): void {
 function generate(args: { config: string }): void {
   const config = parseConfig(args.config);
 
-  const generator = new CodeGenerator(
-    new Set(config.parsing.predefinedTypes ?? []),
-    config.parsing.defaultCustomTags ?? {},
-    config.parsing.skipInvalidMethods ?? false,
-    config.parsing.dropInterfaceIPrefix ?? false
-  );
-
-  const namedTargets = Object.fromEntries(
-    Object.entries(config.parsing.targets)
-      .map(([target, targetConfig]) => ([target, generator.parseTarget(targetConfig.source, targetConfig.exportedInterfaceBases !== undefined ? new Set(targetConfig.exportedInterfaceBases) : undefined)]))
-  );
-
-  let sharedTypes = generator.extractSharedTypes(Object.values(namedTargets));
-  sharedTypes = sharedTypes.concat(Object.values(namedTargets).flatMap((target) => target.sharedTypes));
-  generator.printSharedTypes(sharedTypes);
-
-  Object.values(namedTargets).forEach((target) => {
-    generator.printTarget(target.modules);
-  });
-
-  const languageRenderingConfigs = [
-    { language: RenderingLanguage.Swift, renderingConfig: config.rendering.swift },
-    { language: RenderingLanguage.Kotlin, renderingConfig: config.rendering.kotlin },
-  ];
-
-  languageRenderingConfigs.forEach(({ language, renderingConfig }) => {
-    if (renderingConfig === undefined) {
-      return;
-    }
-
-    renderingConfig.renders.forEach((render) => {
-      const target = namedTargets[render.target] as ParsedTarget | undefined;
-      if (target === undefined) {
-        throw new Error(`target ${render.target} is not defined in the configuration file`);
-      }
-      generator.renderModules(target.modules, {
-        language,
-        outputPath: render.outputPath,
-        templatePath: render.template,
-        typeNameMap: renderingConfig.typeNameMap ?? {},
-      });
-    });
-
-    if (sharedTypes.length > 0) {
-      generator.renderNamedTypes(sharedTypes, {
-        language,
-        outputPath: renderingConfig.namedTypesOutputPath,
-        templatePath: renderingConfig.namedTypesTemplatePath,
-        typeNameMap: renderingConfig.typeNameMap ?? {},
-      });
-    }
-  });
+  generateWithConfig(config);
 }
 
 function listOutput(args: { config: string; language?: 'swift' | 'kotlin'; expand: boolean }): void {

--- a/src/generator/CodeGenerator.ts
+++ b/src/generator/CodeGenerator.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { dropIPrefixInCustomTypes, extractSharedTypes, NamedTypeInfo, ParsedModule, ParsedTarget, parseTarget } from './named-types';
+import { dropIPrefixInCustomTypes, extractTargetsSharedTypes, NamedTypeInfo, ParsedModule, ParsedTarget, parseTarget } from './named-types';
 import { Parser } from '../parser/Parser';
 import { renderCode } from '../renderer/renderer';
 import { NamedTypeView, ModuleView, InterfaceTypeView, EnumTypeView } from '../renderer/views';
@@ -42,8 +42,8 @@ export class CodeGenerator {
     return parseTarget(modules);
   }
 
-  extractSharedTypes(targets: ParsedTarget[]): NamedTypeInfo[] {
-    return extractSharedTypes(targets);
+  extractTargetsSharedTypes(targets: ParsedTarget[]): NamedTypeInfo[] {
+    return extractTargetsSharedTypes(targets);
   }
 
   printTarget(modules: ParsedModule[]): void {

--- a/src/generator/named-types.ts
+++ b/src/generator/named-types.ts
@@ -63,7 +63,7 @@ export function parseTarget(modules: Module[]): ParsedTarget {
   };
 }
 
-export function extractSharedTypes(targets: ParsedTarget[]): NamedTypeInfo[] {
+export function extractTargetsSharedTypes(targets: ParsedTarget[]): NamedTypeInfo[] {
   const typeTargetsMap: Record<string, [NamedTypeInfo, Set<ParsedTarget>]> = {};
 
   targets.forEach((target) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
 export * from './types';
+
+export * from './generator/named-types';
+export * from './generator/CodeGenerator';


### PR DESCRIPTION
Export `CodeGenerator` and modify its APIs to be more direct use friendly. Behavior of CLI generation remains the same.