### PR TITLE
Add config "tsconfigPath" for parsing target

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Create a json configuration file in your project:
   "parsing": {
     "targets": {
       "default": {
-        "source": ["path/to/interfaces.ts"]
+        "source": ["path/to/interfaces.ts"],
+        "tsconfigPath": "path/to/tsconfigPath"
       }
     }
   },

--- a/documentation/generated/interfaces/ParseConfiguration.md
+++ b/documentation/generated/interfaces/ParseConfiguration.md
@@ -50,11 +50,34 @@ Skip the code generation for invalid methods. If `false`, the code generation wi
 
 ___
 
-### source
+### targets
 
-• **source**: `Record`<`string`, `string`[]\>
+• **targets**: `{"source", "exportedInterfaceBases", "tsconfigPath"}`
 
-Scoped source file paths. The key is the scope name and the value is an array of the source file paths. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are allowed.
+Describe the target interfaces to be parsed, including the below properties:
+
+#### source
+
+• **source**: `string[]`
+
+Scoped source file paths. The array of the source file paths for one target. [Glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) are allowed.
 If it is a relative path, it will be resolved based on the configuration file path.
 
-For example, `{ "api": ["src/api/IEditor.ts", "src/bridge/*.ts"] }`
+For example, `["src/api/IEditor.ts", "src/bridge/*.ts"]`
+
+#### exportedInterfaceBases
+
+• `Optional` **exportedInterfaceBases**: `string`[]
+
+Interface names for detecting exported modules. If defined, only interfaces that extends the specified interfaces will be parsed.
+If not defined, interfaces with JSDoc tag `@shouldExport true` would be parsed.
+For example, set it to `["ExportedInterface"]`, all such interfaces would be exported:
+```ts
+interface SomeInterface extends ExportedInterface {}
+```
+
+#### tsconfigPath
+
+• `Optional` **tsconfigPath**: `string`
+
+Path to the tsconfig.json file. If not defined, the default tsconfig.json file will be used.

--- a/documentation/generated/interfaces/ParseConfiguration.md
+++ b/documentation/generated/interfaces/ParseConfiguration.md
@@ -52,9 +52,9 @@ ___
 
 ### targets
 
-• **targets**: `{"source", "exportedInterfaceBases", "tsconfigPath"}`
+• **targets**: `Record<string, {"source", "exportedInterfaceBases", "tsconfigPath"}>`
 
-Describe the target interfaces to be parsed, including the below properties:
+Describe the target interfaces to be parsed, the key is the name of the target, and the value is an object including the below properties:
 
 #### source
 

--- a/src/cli/generate.ts
+++ b/src/cli/generate.ts
@@ -12,7 +12,14 @@ export function generateWithConfig(config: Configuration): void {
 
   const namedTargets = Object.fromEntries(
     Object.entries(config.parsing.targets)
-      .map(([target, targetConfig]) => ([target, generator.parseTarget(targetConfig.source, targetConfig.exportedInterfaceBases !== undefined ? new Set(targetConfig.exportedInterfaceBases) : undefined)]))
+      .map(([target, targetConfig]) => ([
+        target,
+        generator.parseTarget(
+          targetConfig.source, 
+          targetConfig.exportedInterfaceBases !== undefined ? new Set(targetConfig.exportedInterfaceBases) : undefined,
+          targetConfig.tsconfigPath
+          )
+        ]))
   );
 
   let sharedTypes = generator.extractTargetsSharedTypes(Object.values(namedTargets));

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -17,6 +17,10 @@ export interface TargetParseConfiguration {
    * ```
    */
   exportedInterfaceBases?: string[];
+  /**
+   * Provide a specific path for the `tsconfig.json` file.
+   */
+  tsconfigPath?: string;
 }
 
 /**

--- a/src/generator/CodeGenerator.ts
+++ b/src/generator/CodeGenerator.ts
@@ -29,8 +29,8 @@ export class CodeGenerator {
     private readonly dropInterfaceIPrefix: boolean,
   ) {}
 
-  parseTarget(interfacePaths: string[], exportedInterfaceBases?: Set<string>): ParsedTarget {
-    const parser = new Parser(interfacePaths, this.predefinedTypes, this.skipInvalidMethods, exportedInterfaceBases);
+  parseTarget(interfacePaths: string[], exportedInterfaceBases?: Set<string>, tsconfigPath?: string): ParsedTarget {
+    const parser = new Parser(interfacePaths, this.predefinedTypes, this.skipInvalidMethods, exportedInterfaceBases, tsconfigPath);
     const modules = parser.parse();
 
     modules.forEach((module) => applyDefaultCustomTags(module, this.defaultCustomTags));

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,7 +11,7 @@ export function withTempParser(sourceCode: string, handler: (parser: Parser) => 
   const filePath = path.join(tempPath, `${UUID()}.ts`);
   fs.writeFileSync(filePath, sourceCode);
 
-  const parser = new Parser([filePath], predefinedTypes, false, undefined);
+  const parser = new Parser([filePath], predefinedTypes, false, undefined, undefined);
   handler(parser);
 
   fs.rmdirSync(tempPath, { recursive: true });


### PR DESCRIPTION
Sometimes the TS code cannot be parsed with the empty options. Add this to provide the config manually.