### PR TITLE
Add `` to "default" Swift enum value

### DIFF
--- a/demo/basic/generated/kotlin/BridgeTypes.kt
+++ b/demo/basic/generated/kotlin/BridgeTypes.kt
@@ -38,6 +38,7 @@ data class OverriddenFullSize(
 )
 
 enum class NumEnum(val value: Int) {
+    DEFAULT(0),
     ONE(1),
     TWO(2);
 
@@ -57,13 +58,15 @@ class NumEnumTypeAdapter : JsonSerializer<NumEnum>, JsonDeserializer<NumEnum> {
 }
 
 enum class StringEnum {
+    @SerializedName("default") DEFAULT,
     @SerializedName("a") A,
     @SerializedName("b") B
 }
 
 enum class DefaultEnum(val value: Int) {
-    DEFAULT_VALUE_C(0),
-    DEFAULT_VALUE_D(1);
+    DEFAULT(0),
+    DEFAULT_VALUE_C(1),
+    DEFAULT_VALUE_D(2);
 
     companion object {
         fun find(value: Int) = values().find { it.value == value }

--- a/demo/basic/generated/swift/SharedTypes.swift
+++ b/demo/basic/generated/swift/SharedTypes.swift
@@ -45,19 +45,22 @@ public struct OverriddenFullSize: Codable {
 }
 
 public enum NumEnum: Int, Codable {
+  case `default` = 0
   case one = 1
   case two = 2
 }
 
 public enum StringEnum: String, Codable {
+  case `default` = "default"
   /// Description for enum member a
   case a = "a"
   case b = "b"
 }
 
 public enum DefaultEnum: Int, Codable {
-  case defaultValueC = 0
-  case defaultValueD = 1
+  case `default` = 0
+  case defaultValueC = 1
+  case defaultValueD = 2
 }
 
 public enum OverriddenFullSizeMembersStringUnionType: String, Codable {

--- a/demo/basic/interfaces.ts
+++ b/demo/basic/interfaces.ts
@@ -13,6 +13,7 @@ interface CustomSize {
 }
 
 enum StringEnum {
+  default = 'default',
   /**
    * Description for enum member a
    */
@@ -21,11 +22,13 @@ enum StringEnum {
 }
 
 enum NumEnum {
+  default = 0,
   one = 1,
   two = 2,
 }
 
 enum DefaultEnum {
+  default,
   defaultValueC,
   defaultValueD,
 }

--- a/src/renderer/value-transformer/SwiftValueTransformer.ts
+++ b/src/renderer/value-transformer/SwiftValueTransformer.ts
@@ -129,6 +129,10 @@ export class SwiftValueTransformer implements ValueTransformer {
       return '';
     }
 
+    if (text.toLowerCase() === 'default') {
+      return '`default`';
+    }
+
     let index = 0;
     // Get the index of the first lowercased letter
     while (index < text.length) {


### PR DESCRIPTION
TypeScript enum value `DEFAULT` was converted to `default` in Swift, that caused a naming conflict issue.

To fix it, adding ` `` ` to `default` value of Swift enum while transforming it from ts to Swift.