### PR TITLE
Prevent throwing an exception for invalid methods when skip flag is set

### DIFF
--- a/src/parser/ValueParser.ts
+++ b/src/parser/ValueParser.ts
@@ -602,6 +602,7 @@ export class ValueParser {
         if (error instanceof ValueParserError) {
           if (this.skipInvalidMethods) {
             this.logger.warnSkippedNode(decrationNode, error.message, error.guide);
+            return;
           }
 
           throw error;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -6,15 +6,19 @@ import { Parser } from '../src/parser/Parser';
 import { ValueParserError } from '../src/parser/ValueParserError';
 import { Method, ValueType } from '../src/types';
 
-export function withTempParser(sourceCode: string, handler: (parser: Parser) => void, predefinedTypes: Set<string> = new Set()): void {
+export function withTempSkipParser(sourceCode: string, handler: (parser: Parser) => void, predefinedTypes: Set<string> = new Set(), skipInvalidMethods: boolean = false) {
   const tempPath = fs.mkdtempSync(`${os.tmpdir()}/`);
   const filePath = path.join(tempPath, `${UUID()}.ts`);
   fs.writeFileSync(filePath, sourceCode);
 
-  const parser = new Parser([filePath], predefinedTypes, false, undefined, undefined);
+  const parser = new Parser([filePath], predefinedTypes, skipInvalidMethods, undefined, undefined);
   handler(parser);
 
   fs.rmdirSync(tempPath, { recursive: true });
+}
+
+export function withTempParser(sourceCode: string, handler: (parser: Parser) => void, predefinedTypes: Set<string> = new Set()): void {
+  withTempSkipParser(sourceCode, handler, predefinedTypes, false)
 }
 
 export function withTempMethodParser(methodCode: string, handler: (parseFunc: () => Method | null) => void, predefinedTypes: Set<string> = new Set(), customTypesCode: string = ''): void {


### PR DESCRIPTION
When the `skipInvalidMethods` flag is set, the parser correctly logs when skipping the invalid method but still moves ahead and throws the error. This change adds an early return before throwing an error when the ignore flag is set. 